### PR TITLE
Fix Include Observers

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -1040,7 +1040,7 @@ var msgobs = {
                   options = {
                     mode: 'courses',
                     id: results.contexts[0],
-                    query: 'search_users?search_term=' + v[1],
+                    query: 'users/' + v[1],
                     type: ''
                   };
                 }


### PR DESCRIPTION
Fixed error in Include Observers button where observers were not getting added to Conversation messages addressed to individual students